### PR TITLE
rlw.sh: s/out of date/too old/

### DIFF
--- a/rlw.sh
+++ b/rlw.sh
@@ -277,7 +277,7 @@ export WINEPREFIX="$HOME/.rlw/roblox-wine"
 }
 
 [[ "$(wine --version | sed 's/.*-//')" > "1.7.27" ]] || {
-	spawndialog error "Wine is out of date. Please install version 1.7.28 or greater.\n(expected 1.7.28, got $(wine --version | sed 's/.*-//'))"
+	spawndialog error "Your copy of Wine is too old. Please install version 1.7.28 or greater.\n(expected 1.7.28, got $(wine --version | sed 's/.*-//'))"
 	exit 1
 }
 


### PR DESCRIPTION
This is a mostly stylistic change because I don't think the term "out of date" is correct here. For instance, the latest stable Wine 1.6 release can't run Roblox not because it's outdated/obsolete (it's still supported), but simply because the technology is too old.