### PR TITLE
Changed a few labels, adding GitHub link in menu

### DIFF
--- a/rlw.sh
+++ b/rlw.sh
@@ -242,10 +242,10 @@ export WINEPREFIX="$HOME/.local/share/wineprefixes/roblox-wine"
 
 printf '%b\n' 'Roblox Linux Wrapper '"$rlwversion"'-'"$branch"
 
-#[[ -d ".git" ]] || {
-#	spawndialog error 'Roblox Linux Wrapper does not support running outside of its Git repository.\nPlease clone a copy via the command: git clone https://github.com/alfonsojon/roblox-linux-wrapper'
-#	exit 1
-#}
+[[ -d ".git" ]] || {
+	spawndialog error 'Roblox Linux Wrapper does not support running outside of its Git repository.\nPlease clone a copy via the command: git clone https://github.com/alfonsojon/roblox-linux-wrapper'
+	exit 1
+}
 
 # Don't allow running as root
 if [ "$(id -u)" == "0" ]; then

--- a/rlw.sh
+++ b/rlw.sh
@@ -183,7 +183,7 @@ main () {
 		--column '' \
 		--column 'Options' \
 		TRUE 'Play Roblox' \
-		FALSE 'Play Roblox (Quick Mode)' \
+		FALSE 'Play Roblox (Basic Mode)' \
 		FALSE 'Develop on Roblox (Roblox Studio)' \
 		FALSE 'Reinstall Roblox' \
 		FALSE 'Uninstall Roblox' 2>/dev/null \
@@ -191,7 +191,7 @@ main () {
 	case $sel in
 	'Play Roblox')
 		playerwrapper; main;;
-	'Play Roblox (Quick Mode)')  # Legacy mode is an odd name when it is just as good as the browser mode, if not better. Much quicker. "Quick Mode" is a cheesy name lmao.
+	'Play Roblox (Basic Mode)')  # Legacy mode is an odd name when it is just as good as the browser mode, if not better. Much quicker.
 		playerwrapper legacy; main;;
 	'Develop on Roblox (Roblox Studio)') # ROBLOX's community throws around the term "develop" more than "ROBLOX Studio" sadly :C. Newcomers will know what's what.
 		rwine "$WINEPREFIX/drive_c/users/$USER/Local Settings/Application Data/RobloxVersions/RobloxStudioLauncherBeta.exe" -ide

--- a/rlw.sh
+++ b/rlw.sh
@@ -144,7 +144,7 @@ playerwrapper () {
 				--height=132 2&>/dev/null)
 			GAMEID=$(printf '%s' "$GAMEURL" | cut -d "=" -f 2)
 		if [[ -n "$GAMEID" ]]; then
-			rwine "$(find "$WINEPREFIX" -name RobloxPlayerBeta.exe)" --id "$GAMEID" # ROBLOX is 
+			rwine "$(find "$WINEPREFIX" -name RobloxPlayerBeta.exe)" --id "$GAMEID" 
 		else
 			spawndialog warning "There was an error finding that game, sorry! Try entering the game URL or ID again. "
 			return

--- a/rlw.sh
+++ b/rlw.sh
@@ -36,7 +36,7 @@ rwine () {
 		$winebin "${@:2}" && rwineserver --wait
 	else
 		$winebin "$@" && rwineserver --wait; [[ "$?" = "0" ]] || {
-			spawndialog error "wine closed unsuccessfully.\nSee terminal for details. (exit code $?)"
+			spawndialog error "Wine has sadly closed unsuccessfully.\nSee the terminal for details. (exit code $?)"
 			exit $?
 	}
 	fi
@@ -45,7 +45,7 @@ rwine () {
 rwineboot () {
 	printf '%b\n' " > begin rwineboot ()\n---"
 	$winebootbin; [[ "$?" = "0" ]] || {
-		spawndialog error "wineboot closed unsuccessfully.\nSee terminal for details. (exit code $?)"
+		spawndialog error "wineboot has sadly closed unsuccessfully.\nSee terminal for details. (exit code $?)"
 		exit $?
 	}
 	printf '%b\n' " > end rwineboot ()\n---"
@@ -53,7 +53,7 @@ rwineboot () {
 rwineserver () {
 	printf '%b\n' " > begin rwineserver ()\n---"
 	$wineserverbin "$@"; [[ "$?" = "0" ]] || {
-		spawndialog error "wineserver closed unsuccessfully.\nSee terminal for details. (exit code $?)"
+		spawndialog error "wineserver has sadly closed unsuccessfully.\nSee terminal for details. (exit code $?)"
 		exit $?
 	}
 	printf '%b\n' " > end rwineserver ()\n---"
@@ -67,7 +67,7 @@ rwget () {
 		zenity \
 			--progress \
 			--window-icon="$RBXICON" \
-			--title='Downloading' \
+			--title='Downloading Roblox Linux Wrapper necessities' \
 			--auto-close \
 			--no-cancel \
 			--width=450 \
@@ -98,7 +98,7 @@ rwinetricks () {
 roblox-install () {
 	printf '%b\n' " > begin roblox-install ()\n---"
 	if [[ ! -d "$WINEPREFIX/drive_c" ]]; then
-		spawndialog question 'A working Roblox wineprefix was not found.\nWould you like to install one?'
+		spawndialog question 'Roblox Linux Wrapper doesnt seem to be installed.\nWould you like to install it?'
 		if [[ $? = "0" ]]; then
 			rm -rf "$WINEPREFIX"
 			# Make sure our directories really exist
@@ -112,8 +112,8 @@ roblox-install () {
 			wget -N -r --no-parent -Aexe http://download.cdn.mozilla.net/pub/mozilla.org/firefox/releases/latest-esr/win32/en-US/ -nd -P /tmp/Firefox-Setup/
 			WINEDLLOVERRIDES="winebrowser.exe,winemenubuilder.exe=" rwine /tmp/Firefox-Setup/*.exe /SD | zenity \
 				--window-icon="$RBXICON" \
-				--title='Installing Mozilla Firefox' \
-				--text='Installing Mozilla Firefox Browser ...' \
+				--title='Installing (Windows) Mozilla Firefox' \
+				--text='This is so you can launch games.\nDo not worry, this will not mess up your current Linux FireFox installation.' \
 				--progress \
 				--pulsate \
 				--no-cancel \
@@ -130,6 +130,7 @@ roblox-install () {
 
 playerwrapper () {
 	printf '%b\n' " > begin playerwrapper ()\n---"
+	spawndialog warning "Make sure you've logged in to either Studio or Firefox.\nWithout being logged in, this will make you join as a guest."
 	rwine regsvr32 /i "$(find "$WINEPREFIX" -iname 'RobloxProxy.dll')"
 	if [[ "$1" = legacy ]]; then
 		export GAMEURL=$(\
@@ -137,15 +138,15 @@ playerwrapper () {
 				--title='Roblox Linux Wrapper '"$rlwversion"'-'"$branch" \
 				--window-icon="$RBXICON" \
 				--entry \
-				--text='Paste the URL for the game here.' \
+				--text='Paste the URL or ID for the game here.' \
 				--ok-label='Play' \
 				--width=450 \
-				--height=122 2&>/dev/null)
+				--height=132 2&>/dev/null)
 			GAMEID=$(printf '%s' "$GAMEURL" | cut -d "=" -f 2)
 		if [[ -n "$GAMEID" ]]; then
 			rwine "$(find "$WINEPREFIX" -name RobloxPlayerBeta.exe)" --id "$GAMEID"
 		else
-			spawndialog warning "Invalid game URL or ID."
+			spawndialog warning "There was an error finding that game, sorry! Try entering the URL/ID again. "
 			return
 		fi
 	else
@@ -161,7 +162,7 @@ main () {
 		if [[ $(cat .rlw_epoch) -eq "$rlw_epoch" ]]; then
 			printf '%b\n' "Not automatically overwriting the .desktop file; the epoch version seems up to date (rlw_epoch=$rlw_epoch)."
 		else
-			spawndialog question "Would you like to install the Roblox menu item on your system?"
+			spawndialog question "Would you like to install the Roblox menu item on your system? /nThis will give you a ROBLOX icon so you don't have to run the script every time. "
 			[[ "$?" = "0" ]] && {
 				xdg-desktop-menu install --novendor --mode user "$WRAPPER_DIR/roblox.desktop"
 				echo "$rlw_epoch" > .rlw_epoch
@@ -174,28 +175,29 @@ main () {
 		--title='Roblox Linux Wrapper '"$rlwversion"'-'"$branch"'' \
 		--window-icon="$RBXICON" \
 		--width=480 \
-		--height=230 \
-		--cancel-label='Quit' \
+		--height=256 \
+		--cancel-label='Close' \
 		--list \
-		--text 'What option would you like?' \
+		--text 'What would you like to do on ROBLOX?' \
 		--radiolist \
 		--column '' \
 		--column 'Options' \
 		TRUE 'Play Roblox' \
-		FALSE 'Play Roblox (Legacy Mode)' \
-		FALSE 'Roblox Studio' \
+		FALSE 'Play Roblox (Quick Mode)' \
+		FALSE 'Develop on Roblox (Roblox Studio)' \
 		FALSE 'Reinstall Roblox' \
-		FALSE 'Uninstall Roblox' 2>/dev/null)
+		FALSE 'Uninstall Roblox' 2>/dev/null \
+		FALSE 'Visit the GitHub page')
 	case $sel in
 	'Play Roblox')
 		playerwrapper; main;;
-	'Play Roblox (Legacy Mode)')
+	'Play Roblox (Quick Mode)')  # Legacy mode is an odd name when it is just as good as the browser mode, if not better. Much quicker. "Quick Mode" is a cheesy name lmao.
 		playerwrapper legacy; main;;
-	'Roblox Studio')
+	'Develop on Roblox (Roblox Studio)') # ROBLOX's community throws around the term "develop" more than "ROBLOX Studio" sadly :C. Newcomers will know what's what.
 		rwine "$WINEPREFIX/drive_c/users/$USER/Local Settings/Application Data/RobloxVersions/RobloxStudioLauncherBeta.exe" -ide
 		main ;;
 	'Reinstall Roblox')
-		spawndialog question 'Are you sure you would like to reinstall?'
+		spawndialog question 'Are you sure you want to reinstall ROBLOX Linux Wrapper?'
 		if [[ "$?" = "0" ]]; then
 			rm -rf "$HOME/.rlw"
 			rm -rf "$WINEPREFIX"
@@ -216,6 +218,11 @@ main () {
 		else
 			main
 		fi;;
+		'Visit the GitHub page')
+			URL='https://github.com/alfonsojon/roblox-linux-wrapper'
+			[[ -x $BROWSER ]] && exec "$BROWSER" "$URL" #Find default browser
+			path=$(which xdg-open || which gnome-open) && exec "$path" "$URL"
+			main
 	esac
 	printf '%b\n' " > end main ()\n---"
 }
@@ -235,14 +242,14 @@ export WINEPREFIX="$HOME/.local/share/wineprefixes/roblox-wine"
 
 printf '%b\n' 'Roblox Linux Wrapper '"$rlwversion"'-'"$branch"
 
-[[ -d ".git" ]] || {
-	spawndialog error 'Roblox Linux Wrapper does not support running outside of its Git repository.\nPlease clone a copy via the command: git clone https://github.com/alfonsojon/roblox-linux-wrapper'
-	exit 1
-}
+#[[ -d ".git" ]] || {
+#	spawndialog error 'Roblox Linux Wrapper does not support running outside of its Git repository.\nPlease clone a copy via the command: git clone https://github.com/alfonsojon/roblox-linux-wrapper'
+#	exit 1
+#}
 
 # Don't allow running as root
 if [ "$(id -u)" == "0" ]; then
-   spawndialog error "Roblox Linux Wrapper should not be ran with root permissions."
+   spawndialog error "You're running as root (sudo)!\nThis could mess up Wine so please run this again when you're not in root."
    exit 1
 fi
 
@@ -259,7 +266,7 @@ fi
 
 # Note: git is used for automatic updating, and is recommended.
 [[ -x "$(which git)" ]] || {
-	spawndialog error "git is not installed, or was not found. Please install git\nto enable automatic updates."
+	spawndialog error "git is not installed, or was not found. Please install git\nto enable automatic updates./nsudo apt-get install git "
 }
 # Run dependency check & launch main function
 

--- a/rlw.sh
+++ b/rlw.sh
@@ -222,7 +222,6 @@ main () {
 			URL='https://github.com/alfonsojon/roblox-linux-wrapper'
 			[[ -x $BROWSER ]] && exec "$BROWSER" "$URL" #Find default browser
 			path=$(which xdg-open || which gnome-open) && exec "$path" "$URL"
-			main ;;
 	esac
 	printf '%b\n' " > end main ()\n---"
 }

--- a/rlw.sh
+++ b/rlw.sh
@@ -67,7 +67,7 @@ rwget () {
 		zenity \
 			--progress \
 			--window-icon="$RBXICON" \
-			--title='Downloading Roblox Linux Wrapper necessities' \
+			--title='Downloading ...' \
 			--auto-close \
 			--no-cancel \
 			--width=450 \
@@ -98,7 +98,7 @@ rwinetricks () {
 roblox-install () {
 	printf '%b\n' " > begin roblox-install ()\n---"
 	if [[ ! -d "$WINEPREFIX/drive_c" ]]; then
-		spawndialog question 'Roblox Linux Wrapper doesnt seem to be installed.\nWould you like to install it?'
+		spawndialog question 'Roblox Linux Wrapper is not setup yet\nAre you sure you would like to install it?'
 		if [[ $? = "0" ]]; then
 			rm -rf "$WINEPREFIX"
 			# Make sure our directories really exist
@@ -112,8 +112,8 @@ roblox-install () {
 			wget -N -r --no-parent -Aexe http://download.cdn.mozilla.net/pub/mozilla.org/firefox/releases/latest-esr/win32/en-US/ -nd -P /tmp/Firefox-Setup/
 			WINEDLLOVERRIDES="winebrowser.exe,winemenubuilder.exe=" rwine /tmp/Firefox-Setup/*.exe /SD | zenity \
 				--window-icon="$RBXICON" \
-				--title='Installing (Windows) Mozilla Firefox' \
-				--text='This is so you can launch games.\nDo not worry, this will not mess up your current Linux FireFox installation.' \
+				--title='Installing Mozilla Firefox' \
+				--text='Installing Mozilla Firefox browser ...' \
 				--progress \
 				--pulsate \
 				--no-cancel \
@@ -130,23 +130,23 @@ roblox-install () {
 
 playerwrapper () {
 	printf '%b\n' " > begin playerwrapper ()\n---"
-	spawndialog warning "Make sure you've logged in to either Studio or Firefox.\nWithout being logged in, this will make you join as a guest."
+	#spawndialog warning "Make sure you've logged in to either Studio or Firefox.\nWithout being logged in, this will make you join as a guest."
 	rwine regsvr32 /i "$(find "$WINEPREFIX" -iname 'RobloxProxy.dll')"
-	if [[ "$1" = legacy ]]; then
+	if [[ "$1" = basic ]]; then
 		export GAMEURL=$(\
 			zenity \
 				--title='Roblox Linux Wrapper '"$rlwversion"'-'"$branch" \
 				--window-icon="$RBXICON" \
 				--entry \
-				--text='Paste the URL or ID for the game here.' \
+				--text='Paste the Roblox game URL or ID for the game here.' \
 				--ok-label='Play' \
 				--width=450 \
 				--height=132 2&>/dev/null)
 			GAMEID=$(printf '%s' "$GAMEURL" | cut -d "=" -f 2)
 		if [[ -n "$GAMEID" ]]; then
-			rwine "$(find "$WINEPREFIX" -name RobloxPlayerBeta.exe)" --id "$GAMEID"
+			rwine "$(find "$WINEPREFIX" -name RobloxPlayerBeta.exe)" --id "$GAMEID" # ROBLOX is 
 		else
-			spawndialog warning "There was an error finding that game, sorry! Try entering the URL/ID again. "
+			spawndialog warning "There was an error finding that game, sorry! Try entering the game URL or ID again. "
 			return
 		fi
 	else
@@ -162,7 +162,7 @@ main () {
 		if [[ $(cat .rlw_epoch) -eq "$rlw_epoch" ]]; then
 			printf '%b\n' "Not automatically overwriting the .desktop file; the epoch version seems up to date (rlw_epoch=$rlw_epoch)."
 		else
-			spawndialog question "Would you like to install the Roblox menu item on your system? /nThis will give you a ROBLOX icon so you don't have to run the script every time. "
+			spawndialog question "Would you like to install the Roblox menu item? /nThis will give you a ROBLOX icon so you don't have to use the terminal every time. "
 			[[ "$?" = "0" ]] && {
 				xdg-desktop-menu install --novendor --mode user "$WRAPPER_DIR/roblox.desktop"
 				echo "$rlw_epoch" > .rlw_epoch
@@ -176,7 +176,7 @@ main () {
 		--window-icon="$RBXICON" \
 		--width=480 \
 		--height=256 \
-		--cancel-label='Close' \
+		--cancel-label='Exit' \
 		--list \
 		--text 'What would you like to do on ROBLOX?' \
 		--radiolist \
@@ -191,13 +191,13 @@ main () {
 	case $sel in
 	'Play Roblox')
 		playerwrapper; main;;
-	'Play Roblox (Basic Mode)')  # Legacy mode is an odd name when it is just as good as the browser mode, if not better. Much quicker.
-		playerwrapper legacy; main;;
-	'Develop on Roblox (Roblox Studio)') # ROBLOX's community throws around the term "develop" more than "ROBLOX Studio" sadly :C. Newcomers will know what's what.
+	'Play Roblox (Basic Mode)') 
+		playerwrapper basic; main;;
+	'Develop on Roblox (Roblox Studio)')
 		rwine "$WINEPREFIX/drive_c/users/$USER/Local Settings/Application Data/RobloxVersions/RobloxStudioLauncherBeta.exe" -ide
 		main ;;
 	'Reinstall Roblox')
-		spawndialog question 'Are you sure you want to reinstall ROBLOX Linux Wrapper?'
+		spawndialog question 'Are you sure you want to reinstall Roblox Linux Wrapper?'
 		if [[ "$?" = "0" ]]; then
 			rm -rf "$HOME/.rlw"
 			rm -rf "$WINEPREFIX"
@@ -222,7 +222,7 @@ main () {
 			URL='https://github.com/alfonsojon/roblox-linux-wrapper'
 			[[ -x $BROWSER ]] && exec "$BROWSER" "$URL" #Find default browser
 			path=$(which xdg-open || which gnome-open) && exec "$path" "$URL"
-			main
+			main ;;
 	esac
 	printf '%b\n' " > end main ()\n---"
 }


### PR DESCRIPTION
Changing "Roblox Studio" to "Develop on Roblox (Roblox Studio)"
---
Roblox Corp coins the term "develop" more than anything, so for newer users it would be easier to understand. Plus it matches the pattern of the other menu items.

Github Link
---
New link in the menu to launch GitHub in the default browser.

Change "Legacy" to "Basic"
---
In my opinion - Legacy still works flawlessly and I prefer to use it more than the browser. I wouldn't really consider it a old piece of RLW and it is a pretty nice feature. 

Other stuff
---
I tried to make some dialog's more user friendly, but realizing it wasn't needed removed them. I left some that I think still makes sense in RLW.


---------------------------
Tell me if I missed anything, and sorry if I am not doing this right. GitHub is frustrating to work sometimes. 