### PR TITLE
Add a Wine version chooser

### DIFF
--- a/rlw
+++ b/rlw
@@ -154,10 +154,62 @@ playerwrapper () {
 	printf '%b\n' " > end playerwrapper ()\n---"
 }
 
+winechooser () {
+	sel=$(zenity \
+			--title "Wine Version Selection" \
+			--width=480 \
+			--height=250 \
+			--cancel-label='Exit' \
+			--list \
+			--text 'Select the version of Wine you want to use:' \
+			--radiolist \
+			--column '' \
+			--column 'Options' \
+			TRUE 'Automatic detection (via $PATH)' \
+			FALSE '/usr/bin/wine' \
+			FALSE '/opt/wine-staging/bin/wine' \
+			FALSE 'Enter custom Wine path...')
+	case $sel in
+		'Enter custom Wine path...')
+			winebin=$(zenity --text "Enter custom Wine path" --entry);;
+		'Automatic detection (via $PATH)')
+			# Here, we will literally save '$(which wine)' as the path
+			# so it changes dynamically and isn't immediately executed.
+			winebin='$(which wine)';;
+		*)
+			winebin="$sel"
+	esac
+	printf "%b\n" "Wine path set to: $winebin"
+	if [[ -z "$winebin" ]]; then
+		printf "%b\n" "Clearing Wine choice..."
+		rm -f "$HOME/.rlw/wine_choice"
+	else
+		printf "%b\n" "Saving Wine choice to ~/.rlw/wine_choice"
+		echo "winebin=$winebin" > "$HOME/.rlw/wine_choice"
+		mkdir -p "$HOME/.rlw/"
+		source "$HOME/.rlw/wine_choice"
+		winebootbin="$(dirname $winebin)/wineboot"
+		wineserverbin="$(dirname $winebin)/wineserver"
+		for x in "$winebin" "$winebootbin" "$wineserverbin"; do
+			if [[ -x "$x" ]]; then
+				printf "%b\n" "$(basename $x) path set to $x"
+			else
+				spawndialog error "Could not find $(basename $x) at $x. Are you sure a copy is installed there?"
+				winechooser
+				break
+			fi
+		done
+	fi
+}
+
 main () {
 	printf '%b\n' " > begin main ()\n---"
 	rm -f $HOME/Desktop/ROBLOX*.lnk
 	rm -rf "$HOME/.local/share/applications/wine/Programs/Roblox"
+	if [[ ! -f "$HOME/.rlw/wine_choice" ]]; then
+		printf "%b\n" "No Wine path has been saved yet, starting winechooser..."
+		winechooser
+	fi
 	sel=$(zenity \
 		--title='Roblox Linux Wrapper '"$rlwversion"'' \
 		--window-icon="$RBXICON" \
@@ -172,8 +224,9 @@ main () {
 		TRUE 'Play Roblox' \
 		FALSE 'Play Roblox (Legacy Mode)' \
 		FALSE 'Roblox Studio' \
+		FALSE 'Select Wine Version' \
 		FALSE 'Reinstall Roblox' \
-		FALSE 'Uninstall Roblox'  \
+		FALSE 'Uninstall Roblox' \
 		FALSE 'Visit the GitHub page' 2>/dev/null )
 	case $sel in
 	'Play Roblox')
@@ -205,10 +258,13 @@ main () {
 		else
 			main
 		fi;;
-		'Visit the GitHub page')
-			xdg-open https://github.com/alfonsojon/roblox-linux-wrapper
-			main  # Reopen the menu. Not sure if this should be kept or not. 
-		esac
+	'Select Wine Version')
+		winechooser
+		main;;
+	'Visit the GitHub page')
+		xdg-open https://github.com/alfonsojon/roblox-linux-wrapper
+		main  # Reopen the menu. Not sure if this should be kept or not.
+	esac
 	printf '%b\n' " > end main ()\n---"
 }
 
@@ -224,9 +280,7 @@ else
 	export rlwversion='version-unknown'
 fi
 export WINEARCH=win32
-export winebin="$(which wine)"
-export winebootbin="$(which wineboot)"
-export wineserverbin="$(which wineserver)"
+
 export WINEPREFIX="$HOME/.local/share/wineprefixes/roblox-wine"
 export PULSE_LATENCY_MSEC=60 # Workaround fix for crackling sound (variable used by wine)
 
@@ -237,12 +291,6 @@ if [ "$(id -u)" == "0" ]; then
    spawndialog error "Roblox Linux Wrapper should not be ran with root permissions."
    exit 1
 fi
-
-# Check that everything is here
-[[ -x "$winebin" && -x "$winebootbin" && -x "$wineserverbin" ]] || {
-	spawndialog error "Missing dependencies! Please install wine and try again."
-	exit 1
-}
 
 [[ "$(wine --version | sed 's/.*-//')" > "1.7.27" ]] || {
 	spawndialog error "Your copy of Wine is too old. Please install version 1.7.28 or greater.\n(expected 1.7.28, got $(wine --version | sed 's/.*-//'))"

--- a/rlw
+++ b/rlw
@@ -171,7 +171,8 @@ winechooser () {
 			FALSE 'Enter custom Wine path...')
 	case $sel in
 		'Enter custom Wine path...')
-			winebin=$(zenity --text "Enter custom Wine path" --entry);;
+			winebin=$(zenity --title "Wine Version Selection" \
+					  --text "Enter custom Wine path:" --entry);;
 		'Automatic detection (via $PATH)')
 			# Here, we will literally save '$(which wine)' as the path
 			# so it changes dynamically and isn't immediately executed.
@@ -183,6 +184,8 @@ winechooser () {
 	if [[ -z "$winebin" ]]; then
 		printf "%b\n" "Clearing Wine choice..."
 		rm -f "$HOME/.rlw/wine_choice"
+		spawndialog error "You must enter a valid path."
+		winechooser
 	else
 		printf "%b\n" "Saving Wine choice to ~/.rlw/wine_choice"
 		echo "winebin=$winebin" > "$HOME/.rlw/wine_choice"

--- a/rlw
+++ b/rlw
@@ -25,7 +25,7 @@ spawndialog () {
 	zenity \
 		--no-wrap \
 		--window-icon="$RBXICON" \
-		--title='Roblox Linux Wrapper '"$rlwversion"'' \
+		--title="$rlwversionstring" \
 		--"$1" \
 		--text="$2" 2&> /dev/null
 }
@@ -134,7 +134,7 @@ playerwrapper () {
 	rwine regsvr32 /i "$(find "$WINEPREFIX" -iname 'RobloxProxy.dll')"
 	if [[ "$1" = legacy ]]; then
 		GAMEURL=$(zenity \
-				--title='Roblox Linux Wrapper '"$rlwversion"'' \
+				--title="$rlwversionstring" \
 				--window-icon="$RBXICON" \
 				--entry \
 				--text='Paste the URL for the game here.' \
@@ -229,7 +229,7 @@ main () {
 	fi
 	wineinitialize
 	sel=$(zenity \
-		--title='Roblox Linux Wrapper '"$rlwversion"'' \
+		--title="$rlwversionstring" \
 		--window-icon="$RBXICON" \
 		--width=480 \
 		--height=300 \
@@ -302,7 +302,8 @@ export WINEARCH=win32
 export WINEPREFIX="$HOME/.local/share/wineprefixes/roblox-wine"
 export PULSE_LATENCY_MSEC=60 # Workaround fix for crackling sound (variable used by wine)
 
-printf '%b\n' 'Roblox Linux Wrapper '"$rlwversion"'"'
+rlwversionstring="Roblox Linux Wrapper $rlwversion"
+printf '%b\n' "$rlwversionstring"
 
 # Don't allow running as root
 if [ "$(id -u)" == "0" ]; then

--- a/rlw
+++ b/rlw
@@ -154,6 +154,27 @@ playerwrapper () {
 	printf '%b\n' " > end playerwrapper ()\n---"
 }
 
+wineinitialize () {
+	# Evaluate the Wine path selection, and base the wineboot/wineserver
+	# paths off that.
+	source "$HOME/.rlw/wine_choice"
+	winebootbin="$(dirname $winebin)/wineboot"
+	wineserverbin="$(dirname $winebin)/wineserver"
+	for x in "$winebin" "$winebootbin" "$wineserverbin"; do
+		if [[ -x "$x" ]]; then
+			printf "%b\n" "$(basename $x) path set to $x"
+		else
+			spawndialog error "Could not find $(basename $x) at $x. Are you sure a copy is installed there?"
+			winechooser
+			break
+		fi
+	done
+	[[ "$($winebin --version | sed 's/.*-//')" > "1.7.27" ]] || {
+		spawndialog error "Your copy of Wine is too old. Please install version 1.7.28 or greater.\n(expected 1.7.28, got $(wine --version | sed 's/.*-//'))"
+		exit 1
+	}
+}
+
 winechooser () {
 	sel=$(zenity \
 			--title "Wine Version Selection" \
@@ -175,8 +196,12 @@ winechooser () {
 					  --text "Enter custom Wine path:" --entry);;
 		'Automatic detection (via $PATH)')
 			# Here, we will literally save '$(which wine)' as the path
-			# so it changes dynamically and isn't immediately executed.
-			winebin='$(which wine)';;
+			# so it changes dynamically and isn't immediately evaluated.
+			winebin='$(which wine)'
+			if [[ ! -x "$(eval "echo $winebin")" ]]; then
+				spawndialog error 'Missing dependencies! Please install wine somewhere in $PATH, or select a custom path instead.'
+				exit 1
+			fi;;
 		*)
 			winebin="$sel"
 	esac
@@ -190,19 +215,8 @@ winechooser () {
 		printf "%b\n" "Saving Wine choice to ~/.rlw/wine_choice"
 		echo "winebin=$winebin" > "$HOME/.rlw/wine_choice"
 		mkdir -p "$HOME/.rlw/"
-		source "$HOME/.rlw/wine_choice"
-		winebootbin="$(dirname $winebin)/wineboot"
-		wineserverbin="$(dirname $winebin)/wineserver"
-		for x in "$winebin" "$winebootbin" "$wineserverbin"; do
-			if [[ -x "$x" ]]; then
-				printf "%b\n" "$(basename $x) path set to $x"
-			else
-				spawndialog error "Could not find $(basename $x) at $x. Are you sure a copy is installed there?"
-				winechooser
-				break
-			fi
-		done
 	fi
+	wineinitialize
 }
 
 main () {
@@ -213,6 +227,7 @@ main () {
 		printf "%b\n" "No Wine path has been saved yet, starting winechooser..."
 		winechooser
 	fi
+	wineinitialize
 	sel=$(zenity \
 		--title='Roblox Linux Wrapper '"$rlwversion"'' \
 		--window-icon="$RBXICON" \
@@ -294,10 +309,5 @@ if [ "$(id -u)" == "0" ]; then
    spawndialog error "Roblox Linux Wrapper should not be ran with root permissions."
    exit 1
 fi
-
-[[ "$(wine --version | sed 's/.*-//')" > "1.7.27" ]] || {
-	spawndialog error "Your copy of Wine is too old. Please install version 1.7.28 or greater.\n(expected 1.7.28, got $(wine --version | sed 's/.*-//'))"
-	exit 1
-}
 
 roblox-install && main

--- a/rlw
+++ b/rlw
@@ -105,7 +105,7 @@ roblox-install () {
 			mkdir -p "$HOME/.local/share/wineprefixes"
 			rwineboot
 			# ddr=gdi: Causes graphical problems in mutter/gala (GNOME Shell/Elementary OS)
-			rwinetricks ddr=gdi sound=alsa # Fix for crackling under 14.04
+			rwinetricks ddr=gdi sound=alsa # Fix for crackling sound under Ubuntu 14.04
 			[[ "$?" = 0 ]] || {
 				spawndialog error "Wine prefix not generated successfully.\nSee terminal for more details. (exit code $?)"
 				exit $?
@@ -263,7 +263,7 @@ main () {
 		main;;
 	'Visit the GitHub page')
 		xdg-open https://github.com/alfonsojon/roblox-linux-wrapper
-		main  # Reopen the menu. Not sure if this should be kept or not.
+		main
 	esac
 	printf '%b\n' " > end main ()\n---"
 }

--- a/rlw
+++ b/rlw
@@ -276,7 +276,7 @@ main () {
 		else
 			main
 		fi;;
-	'Select Wine Version')
+	'Select Wine Release')
 		winechooser
 		main;;
 	'Visit the GitHub page')

--- a/rlw
+++ b/rlw
@@ -177,7 +177,7 @@ wineinitialize () {
 
 winechooser () {
 	sel=$(zenity \
-			--title "Wine Version Selection" \
+			--title "Wine Release Selection" \
 			--width=480 \
 			--height=250 \
 			--cancel-label='Exit' \
@@ -192,7 +192,7 @@ winechooser () {
 			FALSE 'Enter custom Wine path...')
 	case $sel in
 		'Enter custom Wine path...')
-			winebin=$(zenity --title "Wine Version Selection" \
+			winebin=$(zenity --title "Wine Release Selection" \
 					  --text "Enter custom Wine path:" --entry);;
 		'Automatic detection (via $PATH)')
 			# Here, we will literally save '$(which wine)' as the path


### PR DESCRIPTION
This allows the user to select different Wine paths, such as official Wine and Wine-staging. It defaults to a dynamic search of Wine via `$PATH` lookup, and also allows you to input custom paths. If automatic lookup fails, the script will just exit. Otherwise, the script will ask for input in a loop, repeating if it fails.

winechooser saves its settings to `~/.rlw/wine_choice`, and will run automatically on start if that file doesn't exist. It can also be accessed in the menu via the "Select Wine Version" option.

![](https://dl.dropboxusercontent.com/u/18664770/rlw-winechooser.png)

![](https://dl.dropboxusercontent.com/u/18664770/rlw-winechooser-custompath.png)

### Possible TODO

- [ ] Fit in installation instructions somehow... I originally wanted to add comments to each choice (each choice is a large button), but that requires some complex GTK dialogs that a simple radio list / zenity can't handle.