### PR TITLE
Require a 64-bit operating system and wineprefix

### DIFF
--- a/data/rlw-core.sh
+++ b/data/rlw-core.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Common variables used by all rlw scripts
-export WINEARCH=win32
+export WINEARCH=win64
 export WINEPREFIX="$HOME/.local/share/wineprefixes/roblox-wine"
 export PULSE_LATENCY_MSEC=60 # Workaround fix for crackling sound (variable used by wine)
 

--- a/rlw
+++ b/rlw
@@ -51,6 +51,8 @@ roblox-install () {
 			spawndialog question 'Your current Roblox wineprefix is 32-bit. Roblox requires a 64-bit OS.\nWould you like to reinstall Roblox?'
 			if [[ $? = "0" ]]; then
 				roblox-install uninstall; winechooser; roblox-install install; main
+			else
+				exit 1
 			fi
 		fi;;
 	uninstall)

--- a/rlw
+++ b/rlw
@@ -47,6 +47,12 @@ roblox-install () {
 				exit 1
 			fi
 		fi;;
+		if [[ ! -d "$WINEPREFIX/drive_c/Program Files (x86)" ]]; then
+			spawndialog question 'Your current Roblox wineprefix is 32-bit. Roblox requires a 64-bit OS.\nWould you like to reinstall Roblox?'
+			if [[ $? = "0" ]]; then
+				roblox-install uninstall; winechooser; roblox-install install; main
+			fi
+		fi
 	uninstall)
 		spawndialog question 'This will remove Roblox entirely. Are you sure?'
 		if [[ "$?" = "0" ]]; then

--- a/rlw
+++ b/rlw
@@ -49,7 +49,7 @@ roblox-install () {
 		fi
 		if [[ ! -d "$WINEPREFIX/drive_c/Program Files (x86)" ]]; then
 			spawndialog question 'Your current Roblox wineprefix is 32-bit. Roblox requires a 64-bit OS.\nWould you like to reinstall Roblox?'
-			if [[ $? = "0" ]]; then
+			if [[ "$?" = "0" ]]; then
 				roblox-install uninstall; winechooser; roblox-install install; main
 			else
 				exit 1

--- a/rlw
+++ b/rlw
@@ -46,13 +46,13 @@ roblox-install () {
 			else
 				exit 1
 			fi
-		fi;;
+		fi
 		if [[ ! -d "$WINEPREFIX/drive_c/Program Files (x86)" ]]; then
 			spawndialog question 'Your current Roblox wineprefix is 32-bit. Roblox requires a 64-bit OS.\nWould you like to reinstall Roblox?'
 			if [[ $? = "0" ]]; then
 				roblox-install uninstall; winechooser; roblox-install install; main
 			fi
-		fi
+		fi;;
 	uninstall)
 		spawndialog question 'This will remove Roblox entirely. Are you sure?'
 		if [[ "$?" = "0" ]]; then

--- a/rlw
+++ b/rlw
@@ -176,4 +176,11 @@ if [ "$(id -u)" == "0" ]; then
 	exit 1
 fi
 
+# Require a 64-bit system
+HOSTARCH="$(uname -m)"
+if [ "$HOSTARCH" != "x86_64" ]; then
+	spawndialog error "Roblox requires a 64-bit operating system. Exiting."
+	exit 1
+fi
+
 roblox-install install && main


### PR DESCRIPTION
Roblox has removed support for Windows 32-bit. This means that Roblox no longer works on 32-bit wineprefixes created by this script. From now on, all wineprefixes created by this script need to be a 64-bit wineprefix, so I have updated the script to implement this change. Because this is an incompatible change, I've also added a few checks (for example, require that Roblox is reinstalled if it detects a 32-bit wineprefix) to make sure nothing breaks.